### PR TITLE
Relax dependency on innertube

### DIFF
--- a/thinking-sphinx.gemspec
+++ b/thinking-sphinx.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activerecord', '~> 2.1'
   s.add_runtime_dependency 'after_commit', '>= 1.0.7'
   s.add_runtime_dependency 'riddle',       '>= 1.5.6'
-  s.add_runtime_dependency 'innertube',    '~> 1.0.2'
+  s.add_runtime_dependency 'innertube',    '~> 1.0'
 
   s.add_development_dependency 'appraisal',     '0.4.0'
   s.add_development_dependency 'cucumber',      '1.0.2'


### PR DESCRIPTION
We're still using thinking-sphinx 1.5.0 but also want to use the latest innertube (v1.1 only adds features, is compatible). This relaxes the version in the Gemfile to be semver friendly.
